### PR TITLE
Added missing check

### DIFF
--- a/SourceCode/IO/FurnidataIO.cs
+++ b/SourceCode/IO/FurnidataIO.cs
@@ -26,13 +26,11 @@ namespace Habbo_Downloader.IO
                 return await JsonReadHelper.LoadJObjectAsync(path);
 
             if (Directory.Exists(path))
-                return await LoadSplitAsync(path);
-
-            // Path may point to a directory that contains FurnitureData.json
-            var flatProbe = Path.Combine(path, FlatFileName);
-            if (File.Exists(flatProbe))
-                return await JsonReadHelper.LoadJObjectAsync(flatProbe);
-
+            {
+                if (IsSplitDirectory(path)) return await LoadSplitAsync(path);
+                var flatProbe = Path.Combine(path, FlatFileName);
+                if (File.Exists(flatProbe)) return await JsonReadHelper.LoadJObjectAsync(flatProbe);
+            }
             throw new FileNotFoundException($"FurnitureData not found at: {path}");
         }
 


### PR DESCRIPTION
IsSplitDirectory check was missing in FurnidataIO. The check is present in FigureMapIO and FigureDataIO.